### PR TITLE
Update README.md - removed reference to deploy-to-sfdx

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,7 @@ To install using a pre-built package, use the installation links provided [here]
        src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>
 
-### Method 3 : Scratch Org quick deploy
-
-[![Deploy](https://deploy-to-sfdx.com/dist/assets/images/DeployToSFDX.svg)](https://deploy-to-sfdx.com/)
-
-
-### Method 4 : Scratch Org sfdx CLI deploy
+### Method 3 : Scratch Org sfdx CLI deploy
 
 1. Install Salesforce DX. Enable the Dev Hub in your org or sign up for a Dev Hub trial org and install the Salesforce DX CLI. Follow the instructions in the [Salesforce DX Setup Guide](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_intro.htm?search_text=trial%20hub%20org) or in the [App Development with Salesforce DX](https://trailhead.salesforce.com/modules/sfdx_app_dev) Trailhead module.
 


### PR DESCRIPTION
deploy-to-sfdx is no longer a supported deployment method, removing.